### PR TITLE
Add confighandler to handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 install:
 - go get github.com/gorilla/websocket
 - go get github.com/pborman/uuid
+- go get gopkg.in/yaml.v2
 script:
 - mv $GOPATH/src/github.com/JustAnotherOrganization/tiberious $GOPATH/src
 - cd $GOPATH/src/tiberious

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,0 +1,6 @@
+port: ":4002"
+readbuffer: 1024
+writebuffer: 1024
+messagestore: false
+messageexpire: 0
+messageoverflow: 0

--- a/handlers/confighandler.go
+++ b/handlers/confighandler.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"tiberious/types"
+
+	"gopkg.in/yaml.v2"
+)
+
+func setDefaults(config *types.Config) {
+	config.Port = ":4002"
+	// TODO benchmark and tune default buffer-sizes
+	config.ReadBufferSize = 1024
+	config.WriteBufferSize = 1024
+	config.MessageStore = false
+	config.MessageExpire = 0
+	config.MessageOverflow = 0
+}
+
+// InitConfig should be ran during start to load all server configuration data.
+func InitConfig(config *types.Config) {
+	// If no config file is found set defaults.
+	configfile, err := filepath.Abs("./config.yml")
+	if err != nil {
+		log.Println(err)
+		setDefaults(config)
+		return
+	}
+	// If unable to read the file set defaults.
+	configyaml, err := ioutil.ReadFile(configfile)
+	if err != nil {
+		log.Println(err)
+		setDefaults(config)
+		return
+	}
+	// If unable to parse the yaml set defaults.
+	if err := yaml.Unmarshal([]byte(configyaml), &config); err != nil {
+		log.Println(err)
+		setDefaults(config)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,18 +5,20 @@ import (
 	"net/http"
 
 	"tiberious/handlers"
+	"tiberious/types"
 
 	"github.com/gorilla/websocket"
 )
 
-// TODO benchmark and tune buffer-sizes
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-}
+var config types.Config
 
 // TODO move this into a separate handler of some form.
 func newConnection(w http.ResponseWriter, r *http.Request) {
+	var upgrader = websocket.Upgrader{
+		ReadBufferSize:  config.ReadBufferSize,
+		WriteBufferSize: config.WriteBufferSize,
+	}
+
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Println(err)
@@ -27,11 +29,12 @@ func newConnection(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	handlers.InitConfig(&config)
+
 	http.HandleFunc("/", http.NotFound)
 	http.HandleFunc("/ws", newConnection)
-	var port = ":4002"
-	log.Println("Starting Tiberious on", port)
-	if err := http.ListenAndServe(port, nil); err != nil {
+	log.Println("Starting Tiberious on", config.Port)
+	if err := http.ListenAndServe(config.Port, nil); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/types/config.go
+++ b/types/config.go
@@ -1,0 +1,25 @@
+package types
+
+// Config will hold all the standard configuration data for Tiberious
+type Config struct {
+	/* Port used to set what port to run the server on, this should be
+	 * formatted like the following `:4002` (JIM standard ports are 4002
+	 * through 4006) */
+	Port string `yaml:"port"`
+	// TODO benchmark and tune buffer-size defaults
+	// ReadBufferSize used to set the websocket ReadBufferSize (default 1024)
+	ReadBufferSize int `yaml:"readbuffer"`
+	// WriteBufferSize used to set the websocket WriteBufferSize (default 1024)
+	WriteBufferSize int `yaml:"writebuffer"`
+	/* MessageStore defines whether or not to store messages for retrieval at
+	 * a later time instead of throwing them out after passing them on. */
+	MessageStore bool `yaml:"messagestore"`
+	/* MessageExpire can be used to define whether to expire stored messages
+	 * (if MessageStore is enabled)  after a given time period in days (0 means
+	 * they do not expire). */
+	MessageExpire int `yaml:"messageexpire"`
+	/* MessageOverflow can be used to set a max number of stored messages (if
+	 * MessageStore is enabled) where it will start deleting old messages after
+	 * the Overflow size is reached (0 means they do not overflow) */
+	MessageOverflow int `yaml:"messageoverflow"`
+}


### PR DESCRIPTION
Moves default configuration data into confighandler
Allows for setting configuration data via yaml file (config.yml)
Adds an example_config.yml
Adds a .gitignore file to make sure not to upload any local configs
