### PR TITLE
Add a simple logger

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,19 +1,60 @@
 package logger
 
-import "log"
+import (
+	"io"
+	"log"
+	"os"
 
-/* TODO properly handle errors in a more safe manner and remove the damn
- * brackets from every log message...
- * Implement log to file options and possibly set some stuff to only write
- * during debug mode. */
+	"tiberious/settings"
+	"tiberious/types"
+)
+
+var (
+	config types.Config
+	// Use separate loggers so that errors can be more easily tracked
+	errors *log.Logger
+	info   *log.Logger
+)
+
+func init() {
+	config = settings.GetConfig()
+
+	var errwriter io.Writer
+	var infowriter io.Writer
+
+	if config.ErrorLog != "" {
+		var err error
+		errwriter, err = os.OpenFile(config.ErrorLog, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	} else {
+		errwriter = os.Stderr
+	}
+
+	if config.DebugLog != "" {
+		var err error
+		infowriter, err = os.OpenFile(config.DebugLog, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	} else {
+		infowriter = os.Stdout
+	}
+
+	// TODO Find a way to remove the brackets around all the data?
+	errors = log.New(errwriter, "", log.LstdFlags)
+	info = log.New(infowriter, "", log.LstdFlags)
+}
 
 /*Error logs server-side errors, these are harmful and at least during startup
  * should cause the server to not start. */
 func Error(v ...interface{}) {
-	log.Fatalln("error:", v)
+	// TODO possibly make this non-fatal...
+	errors.Fatalln("error: ", v)
 }
 
 // Info logs standard (non-harmful) information.
 func Info(v ...interface{}) {
-	log.Println("info:", v)
+	info.Println("info:", v)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,19 @@
+package logger
+
+import "log"
+
+/* TODO properly handle errors in a more safe manner and remove the damn
+ * brackets from every log message...
+ * Implement log to file options and possibly set some stuff to only write
+ * during debug mode. */
+
+/*Error logs server-side errors, these are harmful and at least during startup
+ * should cause the server to not start. */
+func Error(v ...interface{}) {
+	log.Fatalln("error:", v)
+}
+
+// Info logs standard (non-harmful) information.
+func Info(v ...interface{}) {
+	log.Println("info:", v)
+}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"log"
 	"net/http"
 
 	"tiberious/handlers"
+	"tiberious/logger"
 	"tiberious/settings"
 	"tiberious/types"
 
@@ -22,7 +22,7 @@ func newConnection(w http.ResponseWriter, r *http.Request) {
 
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Println(err)
+		logger.Error(err)
 		return
 	}
 
@@ -36,8 +36,8 @@ func init() {
 func main() {
 	http.HandleFunc("/", http.NotFound)
 	http.HandleFunc("/ws", newConnection)
-	log.Println("Starting Tiberious on", config.Port)
+	logger.Info("Starting Tiberious on", config.Port)
 	if err := http.ListenAndServe(config.Port, nil); err != nil {
-		log.Fatalln(err)
+		logger.Error(err)
 	}
 }

--- a/settings/configuration.go
+++ b/settings/configuration.go
@@ -2,8 +2,8 @@ package settings
 
 import (
 	"io/ioutil"
-	"log"
 	"path/filepath"
+	"tiberious/logger"
 	"tiberious/types"
 
 	"gopkg.in/yaml.v2"
@@ -15,20 +15,20 @@ func init() {
 	// If no config file is found set defaults.
 	configfile, err := filepath.Abs("./config.yml")
 	if err != nil {
-		log.Println(err)
+		logger.Info(err)
 		setDefaults()
 		return
 	}
 	// If unable to read the file set defaults.
 	configyaml, err := ioutil.ReadFile(configfile)
 	if err != nil {
-		log.Println(err)
+		logger.Info(err)
 		setDefaults()
 		return
 	}
 	// If unable to parse the yaml set defaults.
 	if err := yaml.Unmarshal([]byte(configyaml), &config); err != nil {
-		log.Println(err)
+		logger.Info(err)
 		setDefaults()
 	}
 }

--- a/settings/configuration.go
+++ b/settings/configuration.go
@@ -2,8 +2,9 @@ package settings
 
 import (
 	"io/ioutil"
+	"log"
 	"path/filepath"
-	"tiberious/logger"
+
 	"tiberious/types"
 
 	"gopkg.in/yaml.v2"
@@ -11,24 +12,29 @@ import (
 
 var config types.Config
 
+/* Since logger relies on settings for the file location of logs init errors
+ * here are passed directly to the standard logger. */
 func init() {
 	// If no config file is found set defaults.
 	configfile, err := filepath.Abs("./config.yml")
 	if err != nil {
-		logger.Info(err)
+		log.Println(err)
+		log.Println("Using default settings")
 		setDefaults()
 		return
 	}
 	// If unable to read the file set defaults.
 	configyaml, err := ioutil.ReadFile(configfile)
 	if err != nil {
-		logger.Info(err)
+		log.Println(err)
+		log.Println("Using default settings")
 		setDefaults()
 		return
 	}
 	// If unable to parse the yaml set defaults.
 	if err := yaml.Unmarshal([]byte(configyaml), &config); err != nil {
-		logger.Info(err)
+		log.Println(err)
+		log.Println("Using default settings")
 		setDefaults()
 	}
 }
@@ -42,6 +48,8 @@ func setDefaults() {
 	config.MessageExpire = 0
 	config.MessageOverflow = 0
 	config.UserDatabase = 0
+	config.ErrorLog = ""
+	config.DebugLog = ""
 }
 
 // GetConfig returns the current configuration file.

--- a/types/client.go
+++ b/types/client.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"encoding/json"
-	"log"
+	"tiberious/logger"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -27,6 +27,7 @@ func NewClient() (client *Client) {
 	return &Client{}
 }
 
+// Alert handles both full and minimal alerts.
 func (c Client) Alert(code int, message string) error {
 	var ret []byte
 	var err error
@@ -40,11 +41,12 @@ func (c Client) Alert(code int, message string) error {
 		return err
 	}
 
-	log.Println("returned", string(ret), "to client", c.ID.String())
+	logger.Info("returned", string(ret), "to client", c.ID.String())
 	c.Conn.WriteMessage(websocket.BinaryMessage, ret)
 	return nil
 }
 
+// Error handles both full and minimal errors.
 func (c Client) Error(code int, message string) error {
 	var ret []byte
 	var err error
@@ -58,7 +60,7 @@ func (c Client) Error(code int, message string) error {
 		return err
 	}
 
-	log.Println("returned", string(ret), "to client", c.ID.String())
+	logger.Info("returned", string(ret), "to client", c.ID.String())
 	c.Conn.WriteMessage(websocket.BinaryMessage, ret)
 	return nil
 }

--- a/types/client.go
+++ b/types/client.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	"tiberious/logger"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -41,7 +40,6 @@ func (c Client) Alert(code int, message string) error {
 		return err
 	}
 
-	logger.Info("returned", string(ret), "to client", c.ID.String())
 	c.Conn.WriteMessage(websocket.BinaryMessage, ret)
 	return nil
 }
@@ -60,7 +58,6 @@ func (c Client) Error(code int, message string) error {
 		return err
 	}
 
-	logger.Info("returned", string(ret), "to client", c.ID.String())
 	c.Conn.WriteMessage(websocket.BinaryMessage, ret)
 	return nil
 }

--- a/types/config.go
+++ b/types/config.go
@@ -34,4 +34,8 @@ type Config struct {
 	/* RedisUser should be set to the database number to use in redis.
 	 * Unless using redis for something else 0 should suffice. */
 	RedisUser int64 `yaml:"redisuser"`
+	// ErrorLog allows setting a file location to log errors to.
+	ErrorLog string `yaml:"errorlog"`
+	// DebugLog allows setting a file location to log standard information.
+	DebugLog string `yaml:"debuglog"`
 }


### PR DESCRIPTION
Reduces repeat code and makes it easier to change logging in the future.
Tags Errors and Information separately to make it easier to grep.
