### PR TITLE
Check for handshake error.

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,12 @@ func newConnection(w http.ResponseWriter, r *http.Request) {
 
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		logger.Error(err)
+		if _, ok := err.(websocket.HandshakeError); ok {
+			w.WriteHeader(404)
+			w.Write([]byte("Invalid websocket handshake"))
+			return
+		}
+		logger.Error(err) // TODO Don't call logger.Error here?
 		return
 	}
 


### PR DESCRIPTION
Should prevent crashes if you directly go to the websocket route. Also, we should probably handle logging soon because logger.Error calls os.Exit(1).

Connects https://github.com/JustAnotherOrganization/tiberious/issues/45